### PR TITLE
Populate the submodule's tree.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - image: hubci/gotham:0.3
     steps:
       - checkout
+      - run: git submodule update --init --recursive
       - run:
           name: "Build Website With Gotham"
           command: |


### PR DESCRIPTION
This fixes the issue with the theme files not being available to Gotham on uninitialized repos.